### PR TITLE
fix(xbsl-lib-connect): автоопределение релизного статуса .xlib

### DIFF
--- a/.claude/skills/xbsl-lib-connect/SKILL.md
+++ b/.claude/skills/xbsl-lib-connect/SKILL.md
@@ -106,6 +106,8 @@ python3 .claude/skills/xbsl-lib-connect/scripts/lib_connect.py \
 - `version` → `LIB_VERSION`
 - `technology_version` → для Шага 3
 - `project_kind` → если не `Library` — скрипт завершится с ошибкой
+- `has_release` → `HAS_RELEASE` (признак наличия готового релиза)
+- `release_version` → `RELEASE_VERSION` (версия релиза, если `has_release: true`)
 
 ---
 
@@ -153,9 +155,12 @@ Skill("xbsl-deploy", args="Создать проект из файла сбор�
 
 ---
 
-## Шаг 6 — Попросить пользователя выпустить релиз
+## Шаг 6 — Выпустить релиз (только если `HAS_RELEASE: false`)
 
-Вывести инструкцию:
+Если `HAS_RELEASE` из Шага 2 равно `true` — **пропустить этот шаг**.
+`RELEASE_VERSION` уже установлен из Шага 2 (`release_version`). Перейти к Шагу 7.
+
+Если `HAS_RELEASE: false` — вывести инструкцию:
 
 > **Необходимо выпустить релиз библиотеки вручную в панели управления.**
 >

--- a/.claude/skills/xbsl-lib-connect/scripts/lib_connect.py
+++ b/.claude/skills/xbsl-lib-connect/scripts/lib_connect.py
@@ -74,12 +74,16 @@ def action_inspect(file: str) -> None:
 
     meta = parse_simple_yaml(raw)
     project_kind = meta.get('ProjectKind', '')
+    has_release = 'Release' in meta
+    version = meta.get('Version', '')
     result = {
         "vendor": meta.get('Vendor', ''),
         "name": meta.get('Name', ''),
-        "version": meta.get('Version', ''),
+        "version": version,
         "project_kind": project_kind,
         "technology_version": meta.get('TechnologyVersion', ''),
+        "has_release": has_release,
+        "release_version": version if has_release else "",
     }
 
     if project_kind != 'Library':

--- a/tests/skills/xbsl_lib_connect/test_lib_connect.py
+++ b/tests/skills/xbsl_lib_connect/test_lib_connect.py
@@ -35,7 +35,8 @@ def run_main(lc, monkeypatch, capsys, argv: list[str]) -> tuple:
 
 def make_xlib(path: Path, project_kind: str = 'Library',
               vendor: str = 'e1c', name: str = 'TestLib',
-              version: str = '1.0-5', tech_version: str = '') -> Path:
+              version: str = '1.0-5', tech_version: str = '',
+              with_release: bool = False) -> Path:
     """Создать минимальный .xlib ZIP-архив для тестов."""
     assembly_lines = [
         'ManifestVersion: 1.0',
@@ -46,6 +47,9 @@ def make_xlib(path: Path, project_kind: str = 'Library',
     ]
     if tech_version:
         assembly_lines.append(f'TechnologyVersion: {tech_version}')
+    if with_release:
+        assembly_lines.append('Release:')
+        assembly_lines.append('    Created: 2026.01.01 00:00:00')
     assembly = '\n'.join(assembly_lines) + '\n'
 
     xlib_path = path / f'{name}.xlib'
@@ -68,6 +72,16 @@ class TestInspect:
         assert result['name'] == 'TestLib'
         assert result['project_kind'] == 'Library'
         assert result['technology_version'] == '24.1'
+        assert result['has_release'] is False
+        assert result['release_version'] == ''
+
+    def test_inspect_with_release(self, lc, monkeypatch, capsys, tmp_path):
+        xlib = make_xlib(tmp_path, version='2.0.1', with_release=True)
+        captured, code = run_main(lc, monkeypatch, capsys, ['--action', 'inspect', '--file', str(xlib)])
+        assert code == 0
+        result = json.loads(captured.out)
+        assert result['has_release'] is True
+        assert result['release_version'] == '2.0.1'
 
     def test_application_returns_error(self, lc, monkeypatch, capsys, tmp_path):
         xlib = make_xlib(tmp_path, project_kind='Application')


### PR DESCRIPTION
## Summary

- action `inspect` определяет наличие блока `Release` в `Assembly.yaml`
- результат содержит `has_release` и `release_version`
- ручной шаг выпуска релиза пропускается, если релиз уже существует
- добавлен unit-тест для .xlib с готовым релизом

## Test plan

- [x] Полный набор тестов: 400 passed
- [x] `git diff --check`

Closes #76