### PR TITLE
docs: закрепить требование Python 3.10+ для скиллов

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Набор скиллов для AI-агентов, работающих с проектами на платформе **1С:Элемент (XBSL/SBSL)** — язык со статической типизацией для разработки бизнес-приложений.
 
-Во всех командах ниже `{python}` означает `python` в Windows и `python3` в macOS/Linux/WSL. Выбирай команду сразу по текущей ОС, не запускай оба варианта.
+Во всех командах ниже `{python}` означает `python` в Windows и `python3` в macOS/Linux/WSL. Выбранный интерпретатор должен быть Python 3.10+; если сомневаешься, проверь через `{python} --version`. Выбирай команду сразу по текущей ОС, не запускай оба варианта.
 
 ## Структура репозитория
 
@@ -69,7 +69,7 @@ scripts/build_site.py    # сборка GitHub Pages из README и SKILL.md ф�
 Создаёт объект конфигурации (`.yaml` + опционально `.xbsl`). Оркестрирует xbsl-explore и xbsl-uuid. Читает спецификацию из `references/{ТипОбъекта}.md`. Поддерживаемые типы: Перечисление, Справочник, Документ, РегистрСведений, РегистрНакопления, ОбщийМодуль, Структура, ЛокализованныеСтроки, HttpСервис, ГлобальноеКлиентскоеСобытие, КлючДоступа, Отчет.
 
 ### xbsl-deploy
-Управляет приложениями на платформе 1С:Предприятие.Элемент через Console API v2. `scripts/api.py` — самодостаточный HTTP-клиент (только stdlib Python 3). Конфигурируется через env vars: `ELEMENT_BASE_URL`, `ELEMENT_CLIENT_ID`, `ELEMENT_CLIENT_SECRET` (обязательные), `ELEMENT_APP_ID`, `ELEMENT_PROJECT_ID`, `ELEMENT_BRANCH`, `ELEMENT_SPACE_ID` (опциональные).
+Управляет приложениями на платформе 1С:Предприятие.Элемент через Console API v2. `scripts/api.py` — самодостаточный HTTP-клиент (только stdlib Python 3.10+). Конфигурируется через env vars: `ELEMENT_BASE_URL`, `ELEMENT_CLIENT_ID`, `ELEMENT_CLIENT_SECRET` (обязательные), `ELEMENT_APP_ID`, `ELEMENT_PROJECT_ID`, `ELEMENT_BRANCH`, `ELEMENT_SPACE_ID` (опциональные).
 
 ### xbsl-form-info
 Анализирует существующий объект конфигурации и возвращает JSON: `object_path`, `fields`, `tc`, `namespace`, `suggested_layout`, `existing_forms`. **Вызывается перед `xbsl-form-add` и `xbsl-file-add`** для получения структуры объекта.
@@ -170,20 +170,20 @@ compatibility: Requires Python 3.
 
 ### Соглашения по скриптам (`scripts/`)
 
-- **Только stdlib Python 3** — никаких pip-пакетов; скрипты должны работать без виртуального окружения.
+- **Только stdlib Python 3.10+** — никаких pip-пакетов; скрипты должны работать без виртуального окружения.
 - **JSON в stdout** — скрипты выводят результат как JSON; Claude разбирает вывод и продолжает алгоритм.
 - **Лёгкий YAML-парсер** — каждый скрипт содержит функцию `get_yaml_field()` для чтения `.yaml`; внешних библиотек (PyYAML и т.п.) нет.
 - **Exit-коды как сигналы** — `sys.exit(N)` передаёт скиллу специальные состояния (например, `exit(3)` в `access_state.py` = объект с RLS, перенаправить в `xbsl-pattern-rls`).
 
 ### Кроссплатформенность
 
-Во всех командах ниже `{python}` означает `python` в Windows и `python3` в macOS/Linux/WSL. Выбирай команду сразу по текущей ОС, не запускай оба варианта.
+Во всех командах ниже `{python}` означает `python` в Windows и `python3` в macOS/Linux/WSL. Выбранный интерпретатор должен быть Python 3.10+; если сомневаешься, проверь через `{python} --version`. Выбирай команду сразу по текущей ОС, не запускай оба варианта.
 
 - **Запуск Python** — в инструкциях и примерах используй `{python}`, а дочерние Python-процессы запускай через `sys.executable`.
 - **Пути и временные файлы** — в Python-коде используй `pathlib` и `tempfile`; не хардкодь `/tmp`, обратный слеш или прямой слеш как разделитель пути.
 - **Командная оболочка** — не предполагай наличие Bash. Если shell-команда неизбежна, приводи варианты для PowerShell и POSIX либо заменяй её Python-реализацией.
 - **Кодировка** — текстовые файлы открывай с явным `encoding="utf-8"`.
-- **Новый Python-скилл** — добавляй scalar `compatibility: Requires Python 3.`, точную строку из `LAUNCHER_INSTRUCTION` и slug скилла в `DIRECT_PYTHON_SKILLS` файла `tests/python_runtime_contract.py`, затем обновляй контрактные тесты.
+- **Новый Python-скилл** — добавляй точную строку из `LAUNCHER_INSTRUCTION` и slug скилла в `DIRECT_PYTHON_SKILLS` файла `tests/python_runtime_contract.py`; минимальную версию Python меняй централизованно в этом разделе, `README.md` и контрактных тестах.
 
 ### Трёхфазный workflow для изменяющих операций
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs](https://img.shields.io/badge/docs-github_pages-108679?style=flat-square)](https://korolevpavel.github.io/xbsl-ai-skills/)
 [![License](https://img.shields.io/badge/license-MIT-d68048?style=flat-square)](LICENSE)
-[![Python](https://img.shields.io/badge/python-3.x-2f6b94?style=flat-square)](#требования)
+[![Python](https://img.shields.io/badge/python-3.10%2B-2f6b94?style=flat-square)](#требования)
 
 
 
@@ -60,9 +60,9 @@
 ## Требования
 
 - [Claude Code](https://claude.ai/code) или другой AI-агент, поддерживающий скиллы
-- `Python 3` — для работы скиллов `xbsl-uuid`, `xbsl-subsystem-add`, `xbsl-explore`, `xbsl-meta-add`, `xbsl-form-info`, `xbsl-form-add`, `xbsl-file-add`, `xbsl-image-add`, `xbsl-deploy`, `xbsl-pattern-register`, `xbsl-form-cards`, `xbsl-rename`, `xbsl-form-dashboard`, `xbsl-lib-connect`, `xbsl-access-set` и `xbsl-pattern-rls`
+- `Python 3.10+` — для работы скиллов `xbsl-uuid`, `xbsl-subsystem-add`, `xbsl-explore`, `xbsl-meta-add`, `xbsl-form-info`, `xbsl-form-add`, `xbsl-file-add`, `xbsl-image-add`, `xbsl-deploy`, `xbsl-pattern-register`, `xbsl-form-cards`, `xbsl-rename`, `xbsl-form-dashboard`, `xbsl-lib-connect`, `xbsl-access-set` и `xbsl-pattern-rls`
 
-Во всех командах ниже `{python}` означает `python` в Windows и `python3` в macOS/Linux/WSL. Выбирай команду сразу по текущей ОС, не запускай оба варианта.
+Во всех командах ниже `{python}` означает `python` в Windows и `python3` в macOS/Linux/WSL. Выбранный интерпретатор должен быть Python 3.10+; если сомневаешься, проверь через `{python} --version`. Выбирай команду сразу по текущей ОС, не запускай оба варианта.
 
 ## Установка
 

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1153,8 +1153,8 @@ def normalize_runtime_labels(labels: list[str]) -> list[str]:
     normalized: list[str] = []
     for label in labels:
         clean_label = label.strip()
-        if re.search(r"\bpython\s*3\b", clean_label, flags=re.IGNORECASE):
-            normalized.append("Python 3")
+        if re.search(r"\bpython\s*3(?:\.10\+)?\b", clean_label, flags=re.IGNORECASE):
+            normalized.append("Python 3.10+")
         else:
             normalized.append(clean_label)
     return normalized
@@ -1352,7 +1352,7 @@ def collect_skills(readme_text: str, page_map: dict[Path, str]) -> list[SkillPag
         title = str(meta.get("name") or slug).strip()
         runtime = list(meta.get("runtime") or [])
         if not runtime and (path.parent / "scripts").exists():
-            runtime = ["Python 3"]
+            runtime = ["Python 3.10+"]
         skills.append(
             SkillPage(
                 slug=slug,

--- a/tests/python_runtime_contract.py
+++ b/tests/python_runtime_contract.py
@@ -19,8 +19,14 @@ DIRECT_PYTHON_SKILLS = frozenset(
     }
 )
 
-COMPATIBILITY_LINE = "compatibility: Requires Python 3."
+PYTHON_RUNTIME_LABEL = "Python 3.10+"
 LAUNCHER_INSTRUCTION = (
     "Во всех командах ниже `{python}` означает `python` в Windows и `python3` в "
     "macOS/Linux/WSL. Выбирай команду сразу по текущей ОС, не запускай оба варианта."
+)
+VERSIONED_LAUNCHER_INSTRUCTION = (
+    "Во всех командах ниже `{python}` означает `python` в Windows и `python3` в "
+    "macOS/Linux/WSL. Выбранный интерпретатор должен быть Python 3.10+; если "
+    "сомневаешься, проверь через `{python} --version`. Выбирай команду сразу "
+    "по текущей ОС, не запускай оба варианта."
 )

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -4,7 +4,7 @@ import importlib.util
 import sys
 from pathlib import Path
 
-from python_runtime_contract import DIRECT_PYTHON_SKILLS
+from python_runtime_contract import DIRECT_PYTHON_SKILLS, PYTHON_RUNTIME_LABEL
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -34,7 +34,7 @@ def collect_actual_skills():
 def test_parse_frontmatter_normalizes_scalar_python_requirement() -> None:
     frontmatter = "compatibility: Requires Python 3."
 
-    assert build_site.parse_frontmatter(frontmatter)["runtime"] == ["Python 3"]
+    assert build_site.parse_frontmatter(frontmatter)["runtime"] == [PYTHON_RUNTIME_LABEL]
 
 
 def test_parse_frontmatter_normalizes_legacy_nested_python3_requirement() -> None:
@@ -44,7 +44,7 @@ compatibility:
     - python3
 """
 
-    assert build_site.parse_frontmatter(frontmatter)["runtime"] == ["Python 3"]
+    assert build_site.parse_frontmatter(frontmatter)["runtime"] == [PYTHON_RUNTIME_LABEL]
 
 
 def test_collect_skills_normalizes_runtime_for_all_direct_python_skills() -> None:
@@ -57,7 +57,7 @@ def test_collect_skills_normalizes_runtime_for_all_direct_python_skills() -> Non
 
     assert set(runtime_by_slug) == DIRECT_PYTHON_SKILLS
     assert runtime_by_slug == {
-        slug: ["Python 3"] for slug in DIRECT_PYTHON_SKILLS
+        slug: [PYTHON_RUNTIME_LABEL] for slug in DIRECT_PYTHON_SKILLS
     }
 
 

--- a/tests/test_python_runtime_contract.py
+++ b/tests/test_python_runtime_contract.py
@@ -6,9 +6,10 @@ from pathlib import Path
 import pytest
 
 from python_runtime_contract import (
-    COMPATIBILITY_LINE,
     DIRECT_PYTHON_SKILLS,
     LAUNCHER_INSTRUCTION,
+    PYTHON_RUNTIME_LABEL,
+    VERSIONED_LAUNCHER_INSTRUCTION,
 )
 
 
@@ -18,27 +19,14 @@ SKILLS_DIR = ROOT_DIR / ".claude" / "skills"
 BARE_PYTHON_INVOCATION_RE = re.compile(
     r"(?<![\w{])python(?![\w}])\s+(?:-c\b|[^\s`]*\.py\b)"
 )
+SCRIPT_DOCSTRING_LAUNCHER_INSTRUCTION = (
+    "Во всех командах ниже `{python}` означает `python` в Windows и `python3` в "
+    "macOS/Linux/WSL. Выбирай команду сразу по текущей ОС, не запускай оба варианта."
+)
 
 
 def skill_path(slug: str) -> Path:
     return SKILLS_DIR / slug / "SKILL.md"
-
-
-@pytest.mark.parametrize("slug", sorted(DIRECT_PYTHON_SKILLS))
-def test_direct_python_skill_declares_scalar_runtime_compatibility(slug: str) -> None:
-    text = skill_path(slug).read_text(encoding="utf-8")
-    opening, separator, remainder = text.partition("\n---\n")
-
-    assert separator, f"{slug}: frontmatter is missing or unterminated"
-    assert opening.startswith("---\n"), f"{slug}: frontmatter must be the first block"
-    compatibility_lines = [
-        line
-        for line in opening[4:].splitlines()
-        if re.match(r"^compatibility\s*:", line)
-    ]
-    assert compatibility_lines == [COMPATIBILITY_LINE]
-    assert remainder
-
 
 @pytest.mark.parametrize("slug", sorted(DIRECT_PYTHON_SKILLS))
 def test_direct_python_skill_explains_cross_platform_launcher(slug: str) -> None:
@@ -76,6 +64,7 @@ def test_bare_python_invocation_pattern_detects_actionable_commands(line: str) -
         '`{python} -c "print(1)"`',
         "#!/usr/bin/env python3",
         LAUNCHER_INSTRUCTION,
+        VERSIONED_LAUNCHER_INSTRUCTION,
     ],
 )
 def test_bare_python_invocation_pattern_ignores_portable_and_shebang_lines(line: str) -> None:
@@ -92,6 +81,10 @@ def test_python3_occurs_only_in_shebangs_or_exact_launcher_instructions() -> Non
             if line == "#!/usr/bin/env python3":
                 continue
             if line.strip() == LAUNCHER_INSTRUCTION:
+                continue
+            if line.strip() == VERSIONED_LAUNCHER_INSTRUCTION:
+                continue
+            if path.suffix == ".py" and line.strip() == SCRIPT_DOCSTRING_LAUNCHER_INSTRUCTION:
                 continue
             relative_path = path.relative_to(ROOT_DIR)
             violations.append(f"{relative_path}:{line_number}: {line.strip()}")
@@ -118,9 +111,10 @@ def test_claude_md_documents_cross_platform_skill_development() -> None:
 
     assert marker in text
     section = text.split(marker, maxsplit=1)[1].split("\n### ", maxsplit=1)[0]
-    assert LAUNCHER_INSTRUCTION in section
+    assert VERSIONED_LAUNCHER_INSTRUCTION in section
     required_fragments = (
         "`{python}`",
+        PYTHON_RUNTIME_LABEL,
         "`sys.executable`",
         "`pathlib`",
         "`tempfile`",
@@ -128,10 +122,9 @@ def test_claude_md_documents_cross_platform_skill_development() -> None:
         "Bash",
         "PowerShell",
         '`encoding="utf-8"`',
-        f"`{COMPATIBILITY_LINE}`",
         "`LAUNCHER_INSTRUCTION`",
         "`DIRECT_PYTHON_SKILLS`",
-        "контрактные тесты",
+        "контрактных тестах",
     )
 
     for fragment in required_fragments:


### PR DESCRIPTION
## Что изменено

- Закреплено требование Python 3.10+ в README и CLAUDE.md.
- Runtime-метка Python-скиллов нормализуется в `Python 3.10+` централизованно при сборке сайта.
- Контрактные тесты теперь проверяют целевые Python-скиллы через `DIRECT_PYTHON_SKILLS` и launcher-инструкцию, но не требуют точной `compatibility`-строки в каждом `SKILL.md`.
- `SKILL.md` и Python-скрипты не меняются: совместимость с Python 3.9 и runtime guard не входят в эту задачу.

## Проверки

- [x] `.venv/bin/python -m pytest` — 431 passed
- [x] `.venv/bin/python scripts/build_site.py`
- [x] `git diff --check origin/master...HEAD`

Closes #85