### PR TITLE
Исправить поиск registry в xbsl-validate для Codex layout

### DIFF
--- a/.claude/skills/xbsl-validate/SKILL.md
+++ b/.claude/skills/xbsl-validate/SKILL.md
@@ -11,21 +11,25 @@ description: >
 
 Во всех командах ниже `{python}` означает `python` в Windows и `python3` в macOS/Linux/WSL. Выбирай команду сразу по текущей ОС, не запускай оба варианта.
 
-Используй CLI:
+Используй CLI из текущего корня `skills`:
 
 ```bash
-{python} .claude/skills/xbsl-validate/scripts/validate.py PATH... [--format text|json]
+{python} <skills-root>/xbsl-validate/scripts/validate.py PATH... [--format text|json]
 ```
+
+В исходниках репозитория это обычно
+`.claude/skills/xbsl-validate/scripts/validate.py`, в установленном Codex
+layout — `~/.codex/skills/xbsl-validate/scripts/validate.py`.
 
 Гарантии:
 
 - только читает входные файлы и каталоги;
 - рекурсивно обходит каталоги и проверяет только `*.yaml`;
 - выдаёт детерминированные diagnostics в `text` или едином JSON envelope;
-- использует `.claude/skills/xbsl-meta-add/object-coverage.json` как
-  единственный registry типов, статусов и владельцев;
-- использует `.claude/skills/xbsl-meta-add/references/types.md` как источник
-  grammar для `Тип`.
+- использует sibling skill `xbsl-meta-add/object-coverage.json` из того же
+  корня `skills` как единственный registry типов, статусов и владельцев;
+- использует `xbsl-meta-add/references/types.md` как источник grammar для
+  `Тип`.
 
 Коды завершения:
 

--- a/.claude/skills/xbsl-validate/scripts/validate.py
+++ b/.claude/skills/xbsl-validate/scripts/validate.py
@@ -14,10 +14,15 @@ except ImportError:  # pragma: no cover - exercised only without dependency inst
     yaml = None
 
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
-COVERAGE_PATH = (
-    REPOSITORY_ROOT / ".claude" / "skills" / "xbsl-meta-add" / "object-coverage.json"
-)
+def find_skills_root(path: Path) -> Path:
+    for parent in path.resolve().parents:
+        if parent.name == "skills":
+            return parent
+    raise RuntimeError("Cannot locate skills root")
+
+
+SKILLS_ROOT = find_skills_root(Path(__file__))
+COVERAGE_PATH = SKILLS_ROOT / "xbsl-meta-add" / "object-coverage.json"
 
 UUID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"

--- a/tests/skills/xbsl_validate/test_validate.py
+++ b/tests/skills/xbsl_validate/test_validate.py
@@ -21,13 +21,17 @@ VALIDATOR_PATH = (
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
-def load_validator():
-    assert VALIDATOR_PATH.exists(), "missing xbsl-validate CLI"
-    spec = importlib.util.spec_from_file_location("xbsl_validate", VALIDATOR_PATH)
+def load_validator_from(path: Path):
+    assert path.exists(), "missing xbsl-validate CLI"
+    spec = importlib.util.spec_from_file_location("xbsl_validate", path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def load_validator():
+    return load_validator_from(VALIDATOR_PATH)
 
 
 def run_cli(args: list[str], capsys):
@@ -124,6 +128,30 @@ def test_valid_supported_fixture_and_empty_directory_are_clean(tmp_path, capsys)
         "diagnostics": [],
         "summary": {"files": 0, "errors": 0, "warnings": 0},
     }
+
+
+def test_installed_skill_layout_uses_sibling_coverage_registry(tmp_path, capsys):
+    skills_root = tmp_path / "skills"
+    installed_validator_dir = skills_root / "xbsl-validate" / "scripts"
+    installed_registry_dir = skills_root / "xbsl-meta-add"
+    installed_validator_dir.mkdir(parents=True)
+    installed_registry_dir.mkdir()
+    installed_validator = installed_validator_dir / "validate.py"
+    installed_registry = installed_registry_dir / "object-coverage.json"
+    shutil.copy2(VALIDATOR_PATH, installed_validator)
+    shutil.copy2(
+        REPOSITORY_ROOT / ".claude" / "skills" / "xbsl-meta-add" / "object-coverage.json",
+        installed_registry,
+    )
+
+    validator = load_validator_from(installed_validator)
+    code = validator.main([str(FIXTURES / "valid_supported")])
+    captured = capsys.readouterr()
+
+    assert validator.COVERAGE_PATH == installed_registry
+    assert code == 0
+    assert captured.out == ""
+    assert captured.err == ""
 
 
 def test_common_yaml_type_and_duplicate_key_errors(capsys):


### PR DESCRIPTION
Что сделано: валидатор больше не привязан к .claude/skills и находит ближайший корень skills; coverage registry берётся из sibling skill xbsl-meta-add в том же корне skills; SKILL.md обновлен для repo-source и Codex-install layout; добавлен regression test для установленного layout skills/xbsl-validate + skills/xbsl-meta-add. Проверки: targeted pytest tests/skills/xbsl_validate/test_validate.py -q; полный pytest (505 passed). Связано с milestone v9.2.2.0: https://github.com/korolevpavel/xbsl-ai-skills/milestone/1